### PR TITLE
Integrate with voltron

### DIFF
--- a/calculon/main.py
+++ b/calculon/main.py
@@ -16,6 +16,7 @@ import bpython.repl
 from bpython.cli import *
 
 from .display import CalculonDisplay
+from .voltron_integration import load_voltron
 
 disp = None
 last_result = None
@@ -113,6 +114,7 @@ def runsource(self, source, filename='<input>', symbol='single', encode=True):
         self.locals['vars'] = disp.vars
         self.locals['repl'] = repl
         self.locals['disp'] = disp
+        load_voltron(self.locals)
 
     # update value from last operation
     try:
@@ -165,7 +167,7 @@ def main():
     bpython.cli.CLIRepl = CalculonRepl
 
     # disable autocomplete, otherwise it appears over the main display
-    # might fix this later and add a config option to enable/disable 
+    # might fix this later and add a config option to enable/disable
     bpython.repl.Repl.complete = lambda s, m: None
 
     # run the bpython repl

--- a/calculon/voltron_integration.py
+++ b/calculon/voltron_integration.py
@@ -1,0 +1,38 @@
+import socket
+
+from .env import *
+
+try:
+    import voltron
+except ImportError:
+    voltron = None
+
+class VoltronProxy(object):
+    config = {
+            'type': 'interactive'
+    }
+    def __init__(self):
+        try:
+            self.client = voltron.comms.InteractiveClient(config=self.config)
+            self.connected = True
+        except Exception as e:
+            self.connected = False
+            raise e
+
+    def __getattr__(self, key):
+        resp = self.client.query({'msg_type': 'interactive',
+                          'query': 'get_register',
+                          'register': key})
+        return resp['value']
+
+
+def load_voltron(locals):
+    if voltron is None:
+        return
+
+    print "Loading voltron"
+    proxy = VoltronProxy()
+    if proxy.connected:
+        locals['V'] = proxy
+    else:
+        return None


### PR DESCRIPTION
Exposes an object V in the repl if it connects to voltron.

Attributes on V map onto the registers of the current inferior

Ends up meaning this works:

![screenshot](https://s3.amazonaws.com/99designs-richo-screenshots/mGF0slYceSuzD.png)

See: https://github.com/snarez/voltron/pull/31
