### PR TITLE
Add watch_expr and unwatch_expr

### DIFF
--- a/calculon/display.py
+++ b/calculon/display.py
@@ -310,9 +310,9 @@ class CalculonDisplay (object):
         x = self.padding['left']
         for idx, value in enumerate(self.exprs):
             # TODO Ditch hardcoded format
-            self.draw_value_at_row(value, 'h', y + idx, str(idx))
+            self.draw_value_at_row(value[0], value[1], y + idx, str(idx))
 
     def draw_expr_labels(self):
         y = self.offset_exprs() + self.padding['vartop']
         for idx, value in enumerate(self.exprs):
-            self.draw_labels_at_row('h', y + idx, str(idx))
+            self.draw_labels_at_row(value[1], y + idx, str(idx))

--- a/calculon/repl.py
+++ b/calculon/repl.py
@@ -84,7 +84,7 @@ class CalculonInterpreter(code.InteractiveInterpreter):
             except KeyError:
                 pass
 
-        disp.set_exprs([expr() for expr in watched_exprs])
+        disp.set_exprs([(expr(), fmt) for expr, fmt in watched_exprs])
 
         return False
 
@@ -151,7 +151,7 @@ def watch(varname, format='h'):
         print("Specify variable name as a string")
 
 def watch_expr(expr, format='h'):
-    watched_exprs.append(expr)
+    watched_exprs.append((expr, format))
 
 def unwatch_expr(idx):
     del watched_exprs[idx]


### PR DESCRIPTION
I wound up backing these off their own infrastructure entirely after a couple of stabs at sharing it in with the watched var stuff got messy. It's a bit duplicated but I'm ok with it.

There are a couple of bugs it surfaced:
- Because the display never refreshes the screen, you get artifacts when you unwatch stuff, especially in the spacing.
