### PR TITLE
Voltron watch hooks

### DIFF
--- a/calculon/repl.py
+++ b/calculon/repl.py
@@ -137,6 +137,9 @@ class CalculonInterpreter(code.InteractiveInterpreter):
             self.locals['_unwatch_expr'] = unwatch_expr
             proxy = VoltronProxy()
             if proxy:
+                if proxy.connected:
+                    cb_proxy = VoltronProxy()
+                    cb_proxy.start_callback_thread(lock, debugger_stopped_callback)
                 self.locals['V'] = proxy
 
         # update value from last operation

--- a/calculon/voltron_integration.py
+++ b/calculon/voltron_integration.py
@@ -45,6 +45,8 @@ class _VoltronProxy(object):
         else:
             raise Exception("Not connected")
 
+    def start_callback_thread(self, lock, callback):
+        return self.client.start_callback_thread(lock, callback)
 
     def connect(self):
         if not self.connected:


### PR DESCRIPTION
It finally works!

There's a couple of rough edges/gotchas:
- Sometimes you get `Warning: 'value'`. This happens at the same time as:

```
(lldb) stepi
error: failed to get API lock
```

I think it's an lldb quirk. It seems ok if you don't have too many watches that are poking at voltron.
- Watching strings crashes everything. It's not directly related to this patch but it's waaay easier to trigger now. I'll probably get a new PR in today once I work out how to best workaround that.
- There's something truly horrific going on inside the voltron proxy's wire format. I _think_ that it's basically two messages back to back which get pulled into a single buffer by `recv` and then confuses pickle. tl;dr it hangs the repl forever, using a second socket to pull in the stop hooks firing in voltron makes the bug go away. At some point I'll work it out.

Anyway. Let me know what you think. Or cowboy merge it. Or whatever.
