### PR TITLE
setup.py: add requests dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     keywords="calculator programmer hex 64-bit",
     url="https://github.com/snare/calculon",
     packages=['calculon'],
-    install_requires=['Pyro4', 'blessed', 'scruffington'],
+    install_requires=['Pyro4', 'blessed', 'scruffington', 'requests'],
     package_data={'calculon': ['config/*']},
     entry_points={'console_scripts': ['calculon=calculon:main']},
     zip_safe=False


### PR DESCRIPTION
fix bug in dependencies where requests should be installed. apparently this supports the voltron integration.

```
/env/bin/calculon console                                                                                                                                                                                 [26/26]
Traceback (most recent call last):
  File "/env/bin/calculon", line 11, in <module>
    load_entry_point('calculon-calc==0.2', 'console_scripts', 'calculon')()
  File "/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 542, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
    return ep.load()
  File "/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2229, in load
    return self.resolve()
  File "/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 2235, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/env/lib/python3.5/site-packages/calculon_calc-0.2-py3.5.egg/calculon/__init__.py", line 3, in <module>
    from .main import *
  File "/env/lib/python3.5/site-packages/calculon_calc-0.2-py3.5.egg/calculon/main.py", line 13, in <module>
    from .voltron_integration import *
  File "/env/lib/python3.5/site-packages/calculon_calc-0.2-py3.5.egg/calculon/voltron_integration.py", line 4, in <module>
    from requests.exceptions import ConnectionError
ImportError: No module named 'requests'
```